### PR TITLE
docs: fix simple typo, multplier -> multiplier

### DIFF
--- a/plugins/video/webm/opus/silk/fixed/encode_frame_FIX.c
+++ b/plugins/video/webm/opus/silk/fixed/encode_frame_FIX.c
@@ -325,7 +325,7 @@ opus_int silk_encode_frame_FIX(
             } else {
                 /* Adjust gain by interpolating */
                 gainMult_Q8 = gainMult_lower + silk_DIV32_16( silk_MUL( gainMult_upper - gainMult_lower, maxBits - nBits_lower ), nBits_upper - nBits_lower );
-                /* New gain multplier must be between 25% and 75% of old range (note that gainMult_upper < gainMult_lower) */
+                /* New gain multiplier must be between 25% and 75% of old range (note that gainMult_upper < gainMult_lower) */
                 if( gainMult_Q8 > silk_ADD_RSHIFT32( gainMult_lower, gainMult_upper - gainMult_lower, 2 ) ) {
                     gainMult_Q8 = silk_ADD_RSHIFT32( gainMult_lower, gainMult_upper - gainMult_lower, 2 );
                 } else

--- a/plugins/video/webm/opus/silk/float/encode_frame_FLP.c
+++ b/plugins/video/webm/opus/silk/float/encode_frame_FLP.c
@@ -312,7 +312,7 @@ opus_int silk_encode_frame_FLP(
             } else {
                 /* Adjust gain by interpolating */
                 gainMult_Q8 = gainMult_lower + ( ( gainMult_upper - gainMult_lower ) * ( maxBits - nBits_lower ) ) / ( nBits_upper - nBits_lower );
-                /* New gain multplier must be between 25% and 75% of old range (note that gainMult_upper < gainMult_lower) */
+                /* New gain multiplier must be between 25% and 75% of old range (note that gainMult_upper < gainMult_lower) */
                 if( gainMult_Q8 > silk_ADD_RSHIFT32( gainMult_lower, gainMult_upper - gainMult_lower, 2 ) ) {
                     gainMult_Q8 = silk_ADD_RSHIFT32( gainMult_lower, gainMult_upper - gainMult_lower, 2 );
                 } else


### PR DESCRIPTION
There is a small typo in plugins/video/webm/opus/silk/fixed/encode_frame_FIX.c, plugins/video/webm/opus/silk/float/encode_frame_FLP.c.

Should read `multiplier` rather than `multplier`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md